### PR TITLE
Add supporting of imagePath instead of image field in fail data

### DIFF
--- a/lib/errors/error-factory.js
+++ b/lib/errors/error-factory.js
@@ -1,24 +1,19 @@
 'use strict';
 
 var q = require('q'),
-    temp = require('temp'),
+    tempFS = require('../temp-fs'),
 
     BaseError = require('./base-error'),
     ImageError = require('./image-error'),
     imageProcessor = require('../image-processor');
 
-temp.track();
-
-exports.buildError = function(data, geminiConfig, options) {
-    if (!data.image && !data.saveDiffTo) {
+exports.buildError = function (data, geminiConfig, options) {
+    if (!data.imagePath && !data.saveDiffTo) {
         return q(new BaseError(data, geminiConfig));
     }
 
-    var tempDir = temp.mkdirSync('gemini-fails'),
-        imagePath = temp.path({dir: tempDir, suffix: '.png'}),
-        saveImg = data.image
-            ? data.image.save.bind(data.image)
-            : data.saveDiffTo.bind(data);
+    var imagePath = data.imagePath || tempFS.resolveImagePath(),
+        saveImg = data.imagePath ? q : data.saveDiffTo.bind(data);
 
     return saveImg(imagePath)
         .then(function() {

--- a/lib/temp-fs.js
+++ b/lib/temp-fs.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var temp = require('temp'),
+    tempDir;
+
+temp.track();
+
+exports.resolveImagePath = function () {
+    tempDir = tempDir || temp.mkdirSync('gemini-fails');
+    return temp.path({ dir: tempDir, suffix: '.png' });
+};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "clear-require": "^1.0.1",
     "coveralls": "^2.11.4",
     "istanbul": "^0.3.20",
     "jscs": "^2.1.1",

--- a/test/lib/temp-fs.js
+++ b/test/lib/temp-fs.js
@@ -1,0 +1,36 @@
+var temp = require('temp'),
+    clearRequire = require('clear-require');
+
+describe('temp-fs', function() {
+    var sandbox = sinon.sandbox.create(),
+        tempFs;
+
+    beforeEach(function() {
+        sandbox.stub(temp, 'mkdirSync').returns('/some/temp/folder');
+
+        clearRequire('../../lib/temp-fs');
+        tempFS = require('../../lib/temp-fs');
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    it('should create temp dir on first call', function() {
+        tempFS.resolveImagePath();
+
+        assert.calledOnce(temp.mkdirSync);
+        assert.calledWith(temp.mkdirSync, 'gemini-fails');
+    });
+
+    it('should create temp dir only once', function() {
+        tempFS.resolveImagePath();
+        tempFS.resolveImagePath();
+
+        assert.calledOnce(temp.mkdirSync);
+    });
+
+    it('should resolve valid path for saving image in temp folder', function() {
+        assert.match(tempFS.resolveImagePath(), /^\/some\/temp\/folder\/.+\.png$/);
+    });
+});

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -34,9 +34,7 @@ module.exports = {
     mkStateErrorStub: function() {
         return _.defaults({
             name: 'StateError',
-            image: {
-                save: sinon.stub().returns(q())
-            }
+            imagePath: '/some/path/to/image'
         }, errorDefaults);
     },
 


### PR DESCRIPTION
@j0tunn @sipayRT 

Implement support of  `imagePath` field instead of `image` field in fail data to reach compatibility with gemini v4.x